### PR TITLE
Add NGINX docs for how to use with proxy by host

### DIFF
--- a/docs/docs/configuration/integration.md
+++ b/docs/docs/configuration/integration.md
@@ -18,6 +18,8 @@ server {
   location /oauth2/ {
     proxy_pass       http://127.0.0.1:4180;
     proxy_set_header Host                    $host;
+    # or if you are using a proxy by DNS/Service Mesh and can't rewrite the Host
+    # proxy_set_header X-Forwarded-Host 	     $host;
     proxy_set_header X-Real-IP               $remote_addr;
     proxy_set_header X-Auth-Request-Redirect $request_uri;
     # or, if you are handling multiple domains:
@@ -26,6 +28,8 @@ server {
   location = /oauth2/auth {
     proxy_pass       http://127.0.0.1:4180;
     proxy_set_header Host             $host;
+    # or if you are using a proxy by DNS/Service Mesh and can't rewrite the Host
+    # proxy_set_header X-Forwarded-Host 	     $host;
     proxy_set_header X-Real-IP        $remote_addr;
     proxy_set_header X-Forwarded-Uri  $request_uri;
     # nginx auth_request includes headers but not body


### PR DESCRIPTION
## Description
Adds some documentation on setup for nginx when using a proxy by hostname instead of IP address. This makes use of the check for `X-Forwarded-Host` which can lead to some strange undefined behavior if not set in all appropriate locations in nginx config. 

## Motivation and Context
Having been stuck debugging a problem for many hours, and almost creating a gross large git pull request, finally figured out why my cookies weren't getting set on token refresh. It was because I wasn't passing the `X-Forwarded-Host` to the `/auth` endpoint.

## How Has This Been Tested?
I tested the crap out of this. Like a boss.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [X] I have created a feature (non-master) branch for my PR.
- [ ] I have written tests for my code changes.
